### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/bosun-ai/vader-sentimental/releases/tag/v0.1.0) - 2024-12-01
+
+### Added
+
+- Production ready library + 10x performance improvement  ([#1](https://github.com/bosun-ai/vader-sentimental/pull/1))
+
+### Other
+
+- *(README)* Fix image
+- version 0.1.1
+- Remove println! macros
+- Add Mariana as an author, so she can have rights on the cargo package
+- Merge pull request [#2](https://github.com/bosun-ai/vader-sentimental/pull/2) from ambaxter/add_unicase
+- Merge pull request [#1](https://github.com/bosun-ai/vader-sentimental/pull/1) from ambaxter/master
+- Adding extra info to the package
+- Add license
+- Fixed handling of emoji w/o whitespace seperation
+- Added support for special idioms
+- Created READ_ME.md
+- Created LICENSE
+- Added license/citations
+- Added demo module
+- Created src/test.rs
+- Updated src/lib.rs
+- Moved SentimentAnalyser to root
+- Added basic functionality for SIA::polarity_scores()
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `vader-sentimental`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/bosun-ai/vader-sentimental/releases/tag/v0.1.0) - 2024-12-01

### Added

- Production ready library + 10x performance improvement  ([#1](https://github.com/bosun-ai/vader-sentimental/pull/1))

### Other

- *(README)* Fix image
- version 0.1.1
- Remove println! macros
- Add Mariana as an author, so she can have rights on the cargo package
- Merge pull request [#2](https://github.com/bosun-ai/vader-sentimental/pull/2) from ambaxter/add_unicase
- Merge pull request [#1](https://github.com/bosun-ai/vader-sentimental/pull/1) from ambaxter/master
- Adding extra info to the package
- Add license
- Fixed handling of emoji w/o whitespace seperation
- Added support for special idioms
- Created READ_ME.md
- Created LICENSE
- Added license/citations
- Added demo module
- Created src/test.rs
- Updated src/lib.rs
- Moved SentimentAnalyser to root
- Added basic functionality for SIA::polarity_scores()
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).