### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/bosun-ai/vader-sentimental/compare/v0.1.0...v0.1.1) - 2024-12-01
+
+### Other
+
+- *(deps)* Remove maplit
+- release v0.1.0 ([#2](https://github.com/bosun-ai/vader-sentimental/pull/2))
+
 ## [0.1.0](https://github.com/bosun-ai/vader-sentimental/releases/tag/v0.1.0) - 2024-12-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vader-sentimental"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vader-sentimental"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   "Timon Vonk <mail@timonv.nl>",
   "Chris <chriswong21@berkeley.edu>",


### PR DESCRIPTION
## 🤖 New release
* `vader-sentimental`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/bosun-ai/vader-sentimental/compare/v0.1.0...v0.1.1) - 2024-12-01

### Other

- *(deps)* Remove maplit
- release v0.1.0 ([#2](https://github.com/bosun-ai/vader-sentimental/pull/2))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).