### PR TITLE
Add public access to `SentimentIntensity` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ mod sentiment_intensity_analyzer;
 mod static_resources;
 mod util;
 
+pub use crate::sentiment_intensity_analyzer::SentimentIntensity;
 pub use crate::sentiment_intensity_analyzer::SentimentIntensityAnalyzer;


### PR DESCRIPTION
Right now, the `SentimentIntensity` struct is private, although it is the output for the major export of the library which makes for an extrmely inflexible and unusable API. As far as I could see, wrapping functions was  virtually impossible without deserializing the data from a vector of strings and reserializing it into an identical type that is available to the module. This is a really trivial change, but would make a huge difference in usability and quality of life for users.

